### PR TITLE
Reorder hotkeys, fix audio double play issues.

### DIFF
--- a/components/play-button.tsx
+++ b/components/play-button.tsx
@@ -2,7 +2,7 @@ import { Button } from "@mantine/core";
 import { useHotkeys } from "@mantine/hooks";
 
 let audioContext: AudioContext;
-let audioQueue: string[] = [];
+// let audioQueue: string[] = [];
 let currentlyPlaying = false;
 
 const playAudioBuffer = (buffer: AudioBuffer): Promise<void> => {
@@ -13,9 +13,6 @@ const playAudioBuffer = (buffer: AudioBuffer): Promise<void> => {
     source.onended = () => {
       currentlyPlaying = false;
       resolve();
-      if (audioQueue.length > 0) {
-        playAudio(audioQueue.shift() as string);
-      }
     };
     source.start(0);
   });
@@ -28,7 +25,6 @@ export const playAudio = (urlOrDataURI: string): Promise<void> => {
     }
 
     if (currentlyPlaying) {
-      audioQueue.push(urlOrDataURI);
       return;
     }
 
@@ -84,7 +80,7 @@ export function PlayButton({ dataURI }: { dataURI: string }) {
   return (
     <>
       <Button onClick={playSound} fullWidth>
-        ▶️Play Senten[c]e
+        [C]▶️Play Sentence
       </Button>
     </>
   );

--- a/components/record-button.tsx
+++ b/components/record-button.tsx
@@ -114,7 +114,7 @@ export function RecordButton(props: Props) {
   });
   useHotkeys([
     [
-      "s",
+      "v",
       () => {
         (isRecording ? stop : start)();
       },
@@ -134,11 +134,11 @@ export function RecordButton(props: Props) {
   }
   return isRecording ? (
     <Button onClick={stop} color="red" fullWidth>
-      ⏹️[S]ubmit Answer
+      [V]⏹️Submit Answer
     </Button>
   ) : (
     <Button onClick={start} fullWidth>
-      ⏺️{buttonText} [S]
+      [V]⏺️{buttonText}
     </Button>
   );
 }

--- a/pages/_study_reducer.ts
+++ b/pages/_study_reducer.ts
@@ -1,3 +1,4 @@
+import { playAudio } from "@/components/play-button";
 import { shuffle } from "radash";
 
 export type Quiz = {
@@ -76,11 +77,20 @@ export function gotoNextQuiz(state: State): State {
     }
   }
 
+  let nextState: State;
   if (nextID) {
-    return { ...state, currentQuizIndex: nextQuizIndex };
+    nextState = { ...state, currentQuizIndex: nextQuizIndex };
   } else {
-    return proceedToNextLessonType(state);
+    nextState = proceedToNextLessonType(state);
   }
+  // I am not in love with the fact that we have side effects in a reducer.
+  // Will fix this later.
+  // TODO: Fix this. Move side effects into React component probably.
+  const quiz = currentQuiz(nextState);
+  if (quiz) {
+    playAudio(quiz.quizAudio);
+  }
+  return nextState;
 }
 
 export const newQuizState = (state: Partial<State> = {}): State => {

--- a/pages/study.tsx
+++ b/pages/study.tsx
@@ -1,4 +1,4 @@
-import { PlayButton, playAudio } from "@/components/play-button";
+import { PlayButton } from "@/components/play-button";
 import { RecordButton } from "@/components/record-button";
 import { trpc } from "@/utils/trpc";
 import { Button, Container, Grid, Header } from "@mantine/core";
@@ -10,8 +10,8 @@ import {
   newQuizState,
   quizReducer,
   currentQuiz,
-  gotoNextQuiz,
 } from "./_study_reducer";
+import { useHotkeys } from "@mantine/hooks";
 
 type Props = { quizzes: Quiz[] };
 
@@ -25,6 +25,10 @@ interface CurrentQuizProps {
 
 function CurrentQuiz(props: CurrentQuizProps) {
   const { quiz, onRecord, doFail, doFlag, inProgress } = props;
+  useHotkeys([
+    ["x", () => doFail("" + quiz.id)],
+    ["z", () => doFlag("" + quiz.id)]
+  ]);
   if (!quiz) {
     let message = "";
     if (inProgress) {
@@ -60,12 +64,12 @@ function CurrentQuiz(props: CurrentQuizProps) {
       </Grid.Col>
       <Grid.Col span={4}>
         <Button onClick={() => doFail("" + quiz.id)} fullWidth>
-          ❌[F]ail Item
+          [X]❌Fail Item
         </Button>
       </Grid.Col>
       <Grid.Col span={4}>
         <Button onClick={() => doFlag("" + quiz.id)} fullWidth>
-          🚩Flag Item[R] #{quiz.id}
+          [Z]🚩Flag Item #{quiz.id}
         </Button>
       </Grid.Col>
     </Grid>
@@ -122,14 +126,6 @@ function Study({ quizzes }: Props) {
         onRecord={(audio) => {
           const { id, quizType } = quiz;
           dispatch({ type: "WILL_GRADE" });
-          // Possible race condition here, what happens if
-          // the last result of a lesson is "error"?
-          // TODO Write tests for when the last result is of type
-          // "error".
-          const nextQuiz = currentQuiz(gotoNextQuiz(state));
-          if (nextQuiz) {
-            setTimeout(() => playAudio(nextQuiz.quizAudio), 678);
-          }
           performExam
             .mutateAsync({ id, audio, quizType })
             .then((data) => {
@@ -149,19 +145,6 @@ function Study({ quizzes }: Props) {
         quiz={quiz}
         inProgress={state.numQuizzesAwaitingServerResponse}
       />
-      <br />
-      <pre>{JSON.stringify(quiz, null, 2)}</pre>
-      <br />
-      <pre>
-        {JSON.stringify(
-          {
-            ...state,
-            quizzes: null,
-          },
-          null,
-          2,
-        )}
-      </pre>
     </Container>
   );
 }


### PR DESCRIPTION
I forgot to re-add the hotkeys after a refactor.
I also made a compromise on how audio is played due to an edge case:

A quiz result of "error" at the end of a lesson type makes it impossible to know what the next audio to play is.
As a result, we can't do async/eager quiz progression.