### PR TITLE
Small fixes after the refactor.

### DIFF
--- a/pages/_study_reducer.ts
+++ b/pages/_study_reducer.ts
@@ -114,7 +114,18 @@ export function currentQuiz(state: State): CurrentQuiz | undefined {
 
 function reduce(state: State, action: Action): State {
   switch (action.type) {
+    case "SET_FAILURE":
+      return {
+        ...state,
+        failure: action.value,
+      };
+    case "SET_RECORDING":
+      return {
+        ...state,
+        isRecording: action.value,
+      };
     case "USER_GAVE_UP":
+      return gotoNextQuiz(state, action.id);
     case "FLAG_QUIZ":
       return gotoNextQuiz(state, action.id);
     case "WILL_GRADE":

--- a/pages/study.tsx
+++ b/pages/study.tsx
@@ -173,7 +173,6 @@ function Study(props: Props) {
           .mutateAsync({})
           .catch(needBetterErrorHandler)
           .then((data) => {
-            console.log("TODO: Update new/due/total card stats");
             if (!data) return;
             dispatch({
               type: "ADD_MORE",
@@ -198,7 +197,7 @@ function Study(props: Props) {
     <Container size="xs">
       <Header height={80} style={HEADER_STYLES}>
         <span style={{ fontSize: "24px", fontWeight: "bold" }}>
-          {state.numQuizzesAwaitingServerResponse ? "🔄" : "☑️"}Study
+          Study{!!state.numQuizzesAwaitingServerResponse && "⏳"}
         </span>
       </Header>
       <Grid grow justify="center" align="center">

--- a/server/routers/perform-exam.ts
+++ b/server/routers/perform-exam.ts
@@ -153,7 +153,7 @@ async function listeningTest(transcript: string, card: CardWithPhrase) {
 
 async function speakingTest(transcript: string, card: CardWithPhrase) {
   const { why } = await yesOrNo(
-    `Phrase: <<${card.phrase.term}>>
+    `Phrase: <<${card.phrase.definition}>>
      I said: <<${transcript}>>
      ---
       A Korean language learning app asked me to say the English

--- a/utils/srs.ts
+++ b/utils/srs.ts
@@ -7,11 +7,9 @@ const hours = (h: number) => h / 24;
 // My flavor of SM-2 departs from the original slightly.
 // I review more often in the beginning.
 const EARLY_REVIEW_INTERVAL_MAPPING: Record<number, number> = {
-  0: minutes(0.5),
-  1: minutes(5),
-  2: hours(1),
-  3: hours(5),
-  4: hours(24),
+  0: minutes(5),
+  1: hours(1),
+  2: hours(12),
 };
 
 // Define keys for Spaced Repetition System (SRS) data


### PR DESCRIPTION
What's New?:

 * I adjusted `EARLY_REVIEW_INTERVAL_MAPPING` to be more brief. It seems that the review intervals were a little bit too short.
 * Adjust the speaking prompt slightly. I find that if you tell the LLM the correct answer, it becomes "distracted" by this fact and does not always want to grade based on what the student said.
 * Fix a bug where coaching info UI did not appear after getting a question wrong.