### PR TITLE
Timeouts, study limits, bug fixes

### DIFF
--- a/pages/history.tsx
+++ b/pages/history.tsx
@@ -1,5 +1,5 @@
 import { prismaClient } from "@/server/prisma-client";
-import { cleanString } from "@/utils/clean-string";
+import { exactMatch } from "@/utils/clean-string";
 import { GetServerSidePropsContext } from "next";
 import { getSession } from "next-auth/react";
 import React from "react";
@@ -25,7 +25,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
     })
   )
     .filter((t) => {
-      return cleanString(t.value) !== cleanString(t.card.term);
+      return !exactMatch(t.value, t.card.term);
     })
     .map((t) => {
       return {

--- a/pages/study.tsx
+++ b/pages/study.tsx
@@ -60,13 +60,10 @@ function CardOverview({ quiz }: { quiz: CurrentQuiz }) {
 }
 
 function Study(props: Props) {
-  const cardsById = props.quizzes.reduce(
-    (acc, quiz) => {
-      acc[quiz.id] = quiz;
-      return acc;
-    },
-    {} as Record<number, Quiz>,
-  );
+  const cardsById = props.quizzes.reduce((acc, quiz) => {
+    acc[quiz.id] = quiz;
+    return acc;
+  }, {} as Record<number, Quiz>);
   const newState = newQuizState({
     cardsById,
     totalCards: props.totalCards,
@@ -80,6 +77,11 @@ function Study(props: Props) {
   const editCard = trpc.editCard.useMutation();
   const getNextQuiz = trpc.getNextQuiz.useMutation();
   const needBetterErrorHandler = (error: any) => {
+    notifications.show({
+      title: "Error!",
+      message: "Unexpected error or timeout.",
+      color: "yellow",
+    });
     console.error(error);
   };
   const quiz = currentQuiz(state);

--- a/pages/study.tsx
+++ b/pages/study.tsx
@@ -139,10 +139,16 @@ function Study(props: Props) {
     return (
       <div>
         <h1>No Cards Due</h1>
-        <p>
-          You must <Link href="/create">create new cards</Link> or{" "}
-          <Link href="/cards">import cards from a backup file</Link>.
-        </p>
+        <p>You must:</p>
+        <ul>
+          <li>Not exceed 24 new cards in a 21 hour period.</li>
+          <li>
+            <Link href="/create">Create new cards</Link>.
+          </li>
+          <li>
+            <Link href="/cards">Import cards from a backup file</Link>
+          </li>
+        </ul>
       </div>
     );
   }

--- a/pages/study.tsx
+++ b/pages/study.tsx
@@ -60,10 +60,13 @@ function CardOverview({ quiz }: { quiz: CurrentQuiz }) {
 }
 
 function Study(props: Props) {
-  const cardsById = props.quizzes.reduce((acc, quiz) => {
-    acc[quiz.id] = quiz;
-    return acc;
-  }, {} as Record<number, Quiz>);
+  const cardsById = props.quizzes.reduce(
+    (acc, quiz) => {
+      acc[quiz.id] = quiz;
+      return acc;
+    },
+    {} as Record<number, Quiz>,
+  );
   const newState = newQuizState({
     cardsById,
     totalCards: props.totalCards,

--- a/prisma/migrations/20231116132031_remove_unique_cardid_constraint_on_transcripts/migration.sql
+++ b/prisma/migrations/20231116132031_remove_unique_cardid_constraint_on_transcripts/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX "Transcript_cardId_key";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -38,8 +38,6 @@ model Transcript {
   recordedAt DateTime @default(now())
   card       Card     @relation(fields: [cardId], references: [id], onDelete: Cascade)
   grade      Float    @default(0)
-
-  @@unique([cardId])
 }
 
 model Account {

--- a/server/routers/perform-exam.ts
+++ b/server/routers/perform-exam.ts
@@ -254,8 +254,18 @@ const lessonType = z.union([
 
 export const openai = new OpenAI(configuration);
 
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  const timeoutPromise = new Promise<T>((_resolve, reject) => {
+    setTimeout(() => {
+      reject(new Error("Operation timed out"));
+    }, timeoutMs);
+  });
+
+  return Promise.race([promise, timeoutPromise]);
+}
+
 export async function gptCall(opts: ChatCompletionCreateParamsNonStreaming) {
-  return await openai.chat.completions.create(opts);
+  return withTimeout(openai.chat.completions.create(opts), 3333);
 }
 
 const performExamOutput = z.union([

--- a/server/routers/perform-exam.ts
+++ b/server/routers/perform-exam.ts
@@ -7,7 +7,7 @@ import { procedure } from "../trpc";
 import OpenAI from "openai";
 import { ChatCompletionCreateParamsNonStreaming } from "openai/resources/chat";
 import { SafeCounter } from "@/utils/counter";
-import { cleanString } from "@/utils/clean-string";
+import { exactMatch } from "@/utils/clean-string";
 
 type Quiz = (
   transcript: string,
@@ -200,7 +200,7 @@ async function gradeResp(
 }
 
 async function dictationTest(transcript: string, card: Card) {
-  if (cleanString(transcript) === cleanString(card.term)) {
+  if (exactMatch(transcript, card.term)) {
     console.log("=== Exact match: " + card.term);
     return gradeResp(card, 5, undefined);
   }
@@ -219,7 +219,7 @@ async function dictationTest(transcript: string, card: Card) {
 }
 
 async function listeningTest(transcript: string, card: Card) {
-  if (cleanString(transcript) === cleanString(card.term)) {
+  if (exactMatch(transcript, card.term)) {
     return gradeResp(card, 5, undefined);
   }
   const p = translationPrompt(card.term, transcript);
@@ -228,7 +228,7 @@ async function listeningTest(transcript: string, card: Card) {
 }
 
 async function speakingTest(transcript: string, card: Card) {
-  if (cleanString(transcript) === cleanString(card.definition)) {
+  if (exactMatch(transcript, card.definition)) {
     return gradeResp(card, 5, undefined);
   }
 

--- a/server/routers/perform-exam.ts
+++ b/server/routers/perform-exam.ts
@@ -206,7 +206,7 @@ async function gradeResp(
 }
 
 async function dictationTest(transcript: string, card: Card) {
-  if (exactMatch(transcript, card.definition)) {
+  if (exactMatch(transcript, card.term)) {
     return gradeResp(card, 5, undefined);
   }
   const [grade, why] = await gradedResponse(

--- a/server/routers/perform-exam.ts
+++ b/server/routers/perform-exam.ts
@@ -260,10 +260,13 @@ const lessonType = z.union([
 export const openai = new OpenAI(configuration);
 
 function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  let done = false;
   const timeoutPromise = new Promise<T>((_resolve, reject) => {
     setTimeout(() => {
-      apiTimeout.inc();
-      reject(new Error("Operation timed out"));
+      if (!done) {
+        apiTimeout.inc();
+        reject(new Error("Operation timed out"));
+      }
     }, timeoutMs);
   });
 
@@ -271,7 +274,7 @@ function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
 }
 
 export async function gptCall(opts: ChatCompletionCreateParamsNonStreaming) {
-  return withTimeout(openai.chat.completions.create(opts), 2900);
+  return withTimeout(openai.chat.completions.create(opts), 3000);
 }
 
 const performExamOutput = z.union([

--- a/utils/clean-string.ts
+++ b/utils/clean-string.ts
@@ -1,4 +1,10 @@
-export const cleanString = (str: string) => {
+const cleanString = (str: string) => {
   // This regex matches any whitespace characters or punctuation
-  return str.replace(/[\s\.,\/#!$%\^&\*;:{}=\-_`~()]/g, "");
+  return str.replace(/[\s\.,\/#!$%\^&\*;:{}=\-_`~()]/g, "").toLowerCase();
+};
+
+export const exactMatch = (str: string, query: string) => {
+  const isMatch = cleanString(str) === cleanString(query);
+  console.log(`${isMatch ? "OK" : "NO"}: ${str} === ${query}`);
+  return isMatch;
 };

--- a/utils/transcribe.ts
+++ b/utils/transcribe.ts
@@ -76,7 +76,7 @@ export async function transcribeB64(
       if (!done) {
         resolve({ kind: "error" });
       }
-    }, 8000),
+    }, 4000),
   );
 
   return Promise.race([transcribePromise, timeoutPromise]);

--- a/utils/transcribe.ts
+++ b/utils/transcribe.ts
@@ -76,7 +76,7 @@ export async function transcribeB64(
       if (!done) {
         resolve({ kind: "error" });
       }
-    }, 4000),
+    }, 3000),
   );
 
   return Promise.race([transcribePromise, timeoutPromise]);


### PR DESCRIPTION
# Bug Fixes

 * Drop erroneous database index.
 * Fix exact match criteria used to skip GPT grading

# New Stuff

 * GPT API 3000 ms timeout.
 * Prevent over studying by adding a liit of 24 cards in a 21 hour period (configurable later via user settings table)
 
 