### PR TITLE
Reduce GPT 4 turbo usage by 50%. Maybe improve whisper prompt.

### DIFF
--- a/server/routers/perform-exam.ts
+++ b/server/routers/perform-exam.ts
@@ -163,7 +163,8 @@ export const gradedResponse = async (
 ): Promise<[number, string | undefined]> => {
   userID = userID || "";
   const useGPT4 = approvedUserIDs.includes("" + userID);
-  let model = useGPT4 ? "gpt-4-1106-preview" : "gpt-3.5-turbo-1106";
+  const whichGPT = Math.random() > 0.5 ? "gpt-4-0613" : "gpt-4-1106-preview";
+  let model = useGPT4 ? whichGPT : "gpt-3.5-turbo-1106";
   if (input.includes("REPEAT AFTER ME TEST")) {
     model = "gpt-3.5-turbo-1106"; // Don't waste money on dictation tests.
   }
@@ -178,7 +179,7 @@ export const gradedResponse = async (
     temperature: useGPT4 ? 0.75 : 0,
     function_call: { name: "grade_quiz" },
     functions: [GRADED_RESPONSE],
-    max_tokens: 555,
+    max_tokens: 444,
   });
   if (!answer) {
     return errorReport("No answer");

--- a/utils/transcribe.ts
+++ b/utils/transcribe.ts
@@ -19,8 +19,8 @@ export const captureAudio = (dataURI: string): string => {
 
 type TranscriptionResult = { kind: "OK"; text: string } | { kind: "error" };
 
-const PROMPT_KO = "한국어 학생이 말하고 있습니다: ";
-const PROMPT_EN = "A Korean language learner translates sentences to English.";
+const PROMPT_KO = "다양한 예문을 읽는 연습";
+const PROMPT_EN = "Trascript of an example sentence.";
 
 const transcriptionLength = SafeCounter({
   name: "transcriptionLength",
@@ -58,7 +58,7 @@ export async function transcribeB64(
           text,
         });
       } catch (error) {
-        console.log("serverside transcription error:");
+        console.log("server side transcription error:");
         console.error(error);
         return resolve({ kind: "error" });
       } finally {


### PR DESCRIPTION
I am kind of disappointed with the performance of GPT-4 turbo but also need to balance cost.
False negatives and API errors slow down the speed at which I can study.
This PR reduces GPT 4 turbo usage by 50%. If GPT-4 gets cheaper or if GPT-4turbo becomes more reliable, I can adjust this compromise.
