### PR TITLE
More UI / Display / Scheduling fixes

### DIFF
--- a/koala/auth-helpers.ts
+++ b/koala/auth-helpers.ts
@@ -17,7 +17,6 @@ export const getUserSettings = async (userId?: UserID) => {
     return errorReport("Missing User ID");
   }
   const params = { userId: "" + userId };
-  // Update users lastSeen field:
   prismaClient.user
     .update({
       where: { id: "" + userId },

--- a/koala/fetch-lesson.ts
+++ b/koala/fetch-lesson.ts
@@ -188,7 +188,10 @@ export default async function getLessons(p: GetLessonInputParams) {
         lt: yesterday,
       },
     },
-    orderBy: [{ Card: { langCode: "desc" } }, { nextReview: "desc" }],
+    orderBy: [
+      { Card: { langCode: "desc" } },
+      { nextReview: Math.random() > 0.5 ? "desc" : "asc" }
+    ],
     // Don't select quizzes from the same card.
     // Prevents hinting.
     distinct: ["cardId"],

--- a/koala/fetch-lesson.ts
+++ b/koala/fetch-lesson.ts
@@ -190,7 +190,7 @@ export default async function getLessons(p: GetLessonInputParams) {
     },
     orderBy: [
       { Card: { langCode: "desc" } },
-      { nextReview: Math.random() > 0.5 ? "desc" : "asc" }
+      { nextReview: Math.random() > 0.5 ? "desc" : "asc" },
     ],
     // Don't select quizzes from the same card.
     // Prevents hinting.

--- a/koala/fetch-lesson.ts
+++ b/koala/fetch-lesson.ts
@@ -7,7 +7,7 @@ import { errorReport } from "./error-report";
 import { prismaClient } from "@/koala/prisma-client";
 import { Card } from "@prisma/client";
 
-type LessonType = "listening" | "speaking";
+export type LessonType = "listening" | "speaking";
 
 type GetLessonInputParams = {
   userId: string;

--- a/koala/fetch-lesson.ts
+++ b/koala/fetch-lesson.ts
@@ -217,6 +217,7 @@ export default async function getLessons(p: GetLessonInputParams) {
       lessonType: quiz.quizType as "listening" | "speaking",
       audio,
       langCode: quiz.Card.langCode,
+      lastReview: quiz.lastReview || 0,
     };
   });
 }

--- a/koala/fetch-lesson.ts
+++ b/koala/fetch-lesson.ts
@@ -182,7 +182,7 @@ export default async function getLessons(p: GetLessonInputParams) {
         in: ["listening", "speaking"],
       },
       nextReview: {
-        lt: p.now,
+        lt: p.now || Date.now(),
       },
       lastReview: {
         lt: yesterday,

--- a/koala/fetch-lesson.ts
+++ b/koala/fetch-lesson.ts
@@ -190,7 +190,8 @@ export default async function getLessons(p: GetLessonInputParams) {
     },
     orderBy: [
       { Card: { langCode: "desc" } },
-      { nextReview: Math.random() > 0.5 ? "desc" : "asc" },
+      // 90% old cards, 10% new, for now.
+      { nextReview: Math.random() < 0.9 ? "desc" : "asc" },
     ],
     // Don't select quizzes from the same card.
     // Prevents hinting.

--- a/koala/get-card-or-fail.ts
+++ b/koala/get-card-or-fail.ts
@@ -7,6 +7,9 @@ export async function getCardOrFail(id: number, userId?: string) {
       id,
       userId: userId || "000",
     },
+    include: {
+      Quiz: true,
+    },
   });
   if (!card) {
     return errorReport("Card not found");

--- a/koala/openai.ts
+++ b/koala/openai.ts
@@ -88,7 +88,7 @@ export const yesOrNo = async (input: YesOrNoInput): Promise<YesOrNo> => {
   const jsonString =
     grammarResp?.choices?.[0]?.message?.tool_calls?.[0].function.arguments ||
     "{}";
-  console.log(`===`)
+  console.log(`===`);
   console.log(userInput);
   console.log(question);
   console.log(jsonString);

--- a/koala/quiz-evaluators/evaluator-utils.ts
+++ b/koala/quiz-evaluators/evaluator-utils.ts
@@ -1,0 +1,16 @@
+export const FOOTER = `
+This question is being used to grade a student's work in a
+language learning flashcard app. The student entered the
+text via speech-to-text. They have no control over punctuation
+or spacing, so you should not grade them on these details.
+Also, don't nitpick the details if there are only small differences.
+The goal is to find major problems with meaning or grammar.
+`;
+
+export function strip(input: string): string {
+  // This regex matches any punctuation, space, or number
+  // \p{P} matches any kind of punctuation character
+  // \s matches any whitespace character
+  // \p{N} matches any kind of numeric character in any script
+  return input.replace(/[\p{P}\s\p{N}]/gu, "").toLocaleLowerCase();
+}

--- a/koala/quiz-evaluators/footer.ts
+++ b/koala/quiz-evaluators/footer.ts
@@ -1,6 +1,0 @@
-export const FOOTER = `
-This question is being used to grade a student's work in a
-language learning flashcard app. Don't nitpick the details
-if there are only small differences. The goal is to find major
-problems with meaning or grammar.
-`;

--- a/koala/quiz-evaluators/footer.ts
+++ b/koala/quiz-evaluators/footer.ts
@@ -1,0 +1,6 @@
+export const FOOTER = `
+This question is being used to grade a student's work in a
+language learning flashcard app. Don't nitpick the details
+if there are only small differences. The goal is to find major
+problems with meaning or grammar.
+`;

--- a/koala/quiz-evaluators/listening.ts
+++ b/koala/quiz-evaluators/listening.ts
@@ -1,7 +1,7 @@
 import { template } from "radash";
 import { QuizEvaluator } from "./types";
 import { yesOrNo } from "@/koala/openai";
-import { FOOTER } from "./footer";
+import { FOOTER, strip } from "./evaluator-utils";
 
 const PROMPT = `
 Sentence B: "{{term}}" ({{langCode}})
@@ -17,6 +17,15 @@ export const listening: QuizEvaluator = async (ctx) => {
   const { term, definition, langCode } = card;
   const tplData = { term, definition, langCode };
   const question = template(PROMPT, tplData);
+
+  if (strip(userInput) === strip(definition)) {
+    console.log(`=== Exact match!`);
+    return {
+      result: "pass",
+      userMessage: "Exact match. Nice work!",
+    };
+  }
+
   const listeningYN = await yesOrNo({
     userInput: `Sentence A: ${userInput} (EN)`,
     question,

--- a/koala/quiz-evaluators/listening.ts
+++ b/koala/quiz-evaluators/listening.ts
@@ -1,6 +1,7 @@
 import { template } from "radash";
 import { QuizEvaluator } from "./types";
 import { yesOrNo } from "@/koala/openai";
+import { FOOTER } from "./footer";
 
 const PROMPT = `
 Sentence B: "{{term}}" ({{langCode}})
@@ -10,7 +11,7 @@ When translated, is sentence A equivalent in meaning to sentence B and C?
 The meaning is more important than the words used.
 Punctuation and spacing do not matter for the sake of this question.
 If "NO", why not?
-`;
+` + FOOTER;
 export const listening: QuizEvaluator = async (ctx) => {
   const { userInput, card } = ctx;
   const { term, definition, langCode } = card;

--- a/koala/quiz-evaluators/listening.ts
+++ b/koala/quiz-evaluators/listening.ts
@@ -3,7 +3,8 @@ import { QuizEvaluator } from "./types";
 import { yesOrNo } from "@/koala/openai";
 import { FOOTER, strip } from "./evaluator-utils";
 
-const PROMPT = `
+const PROMPT =
+  `
 Sentence B: "{{term}}" ({{langCode}})
 Sentence C: "{{definition}}" (EN)
 

--- a/koala/quiz-evaluators/speaking.ts
+++ b/koala/quiz-evaluators/speaking.ts
@@ -1,6 +1,7 @@
 import { YesOrNo, yesOrNo } from "@/koala/openai";
 import { QuizEvaluator } from "./types";
 import { template } from "radash";
+import { FOOTER } from "./footer";
 
 const GRAMMAR_PROMPT = `Grade a sentence from a language learning
 app. Answer YES if the sentence is grammatically correct and
@@ -9,7 +10,7 @@ Answer NO if it doesn't follow the language's syntax and semantics
 or isn't in the specified language. Avoid vague responses.
 Incomplete sentences are OK if they are grammatically correct.
 Do not grade spacing. You will be penalized for vague "NO"
-responses.`;
+responses.` + FOOTER;
 
 const MEANING_PROMPT = `
 Sentence B: "{{term}}" ({{langCode}})

--- a/koala/quiz-evaluators/speaking.ts
+++ b/koala/quiz-evaluators/speaking.ts
@@ -1,9 +1,10 @@
 import { YesOrNo, yesOrNo } from "@/koala/openai";
 import { QuizEvaluator } from "./types";
 import { template } from "radash";
-import { FOOTER } from "./footer";
+import { FOOTER, strip } from "./evaluator-utils";
 
-const GRAMMAR_PROMPT = `Grade a sentence from a language learning
+const GRAMMAR_PROMPT =
+  `Grade a sentence from a language learning
 app. Answer YES if the sentence is grammatically correct and
 in the specified language (ISO 639-1:2002 code '{{langCode}}').
 Answer NO if it doesn't follow the language's syntax and semantics
@@ -12,7 +13,8 @@ Incomplete sentences are OK if they are grammatically correct.
 Do not grade spacing. You will be penalized for vague "NO"
 responses.` + FOOTER;
 
-const MEANING_PROMPT = `
+const MEANING_PROMPT =
+  `
 Sentence B: "{{term}}" ({{langCode}})
 Sentence C: "{{definition}}" (EN)
 
@@ -20,7 +22,7 @@ When translated, is sentence A equivalent to sentence B and C?
 The meaning is more important than the words used.
 If "NO", why not?
 Punctuation and spacing do not matter for the sake of this question.
-`;
+` + FOOTER;
 
 const gradeGrammar = async (
   userInput: string,
@@ -54,6 +56,14 @@ const gradeGrammar = async (
 };
 
 export const speaking: QuizEvaluator = async ({ userInput, card, userID }) => {
+  if (strip(userInput) === strip(card.term)) {
+    console.log(`=== Exact match!`);
+    return {
+      result: "pass",
+      userMessage: "Exact match. Nice work!",
+    };
+  }
+
   const result = await gradeGrammar(
     userInput,
     card.term,

--- a/koala/quiz-failure.tsx
+++ b/koala/quiz-failure.tsx
@@ -58,17 +58,17 @@ export function QuizFailure(props: {
           <Grid grow justify="center" align="stretch" gutter="xs">
             <Grid.Col span={4}>
               <Button onClick={props.onClose}>
-                Continue ({HOTKEYS.CONTINUE})
+                Continue ({HOTKEYS.CONTINUE.toUpperCase()})
               </Button>
             </Grid.Col>
             <Grid.Col span={4}>
               <Button onClick={props.onDiscard}>
-                Disagree ({HOTKEYS.DISAGREE})
+                Disagree ({HOTKEYS.DISAGREE.toUpperCase()})
               </Button>
             </Grid.Col>
             <Grid.Col span={4}>
               <Button onClick={props.onFlag}>
-                Flag / Pause ({HOTKEYS.FLAG})
+                Flag / Pause ({HOTKEYS.FLAG.toUpperCase()})
               </Button>
             </Grid.Col>
           </Grid>

--- a/koala/quiz-failure.tsx
+++ b/koala/quiz-failure.tsx
@@ -1,5 +1,5 @@
 import { HOTKEYS } from "@/pages/study";
-import { Button, Grid, Text, Container } from "@mantine/core";
+import { Button, Grid, Text, Container, Table } from "@mantine/core";
 import { useHotkeys } from "@mantine/hooks";
 import Link from "next/link";
 
@@ -39,22 +39,43 @@ export function QuizFailure(props: {
             <h1 style={{ fontSize: "24px", fontWeight: "bold" }}>Incorrect</h1>
           </header>
           <Text>You answered a previous question incorrectly.</Text>
-          <Text>
-            <strong>Quiz type:</strong> {props.lessonType}
-          </Text>
-          <Text>
-            <strong>(A) What you said:</strong> {props.userTranscription}
-          </Text>
-          <Text>
-            <strong>(B) Term:</strong> {props.term}
-          </Text>
-          <Text>
-            <strong>(C) Definition:</strong> {props.definition}
-          </Text>
-          <Text>
-            <strong>Why it's wrong:</strong> {props.rejectionText}
-          </Text>
-          <Text>{linkToEditPage(props.cardId)}</Text>
+          <Table>
+            <tbody>
+              <tr>
+                <td>
+                  <strong>Quiz type:</strong>
+                </td>
+                <td>{props.lessonType}</td>
+              </tr>
+              <tr>
+                <td>
+                  <strong>(A) What you said:</strong>
+                </td>
+                <td>{props.userTranscription}</td>
+              </tr>
+              <tr>
+                <td>
+                  <strong>(B) Term:</strong>
+                </td>
+                <td>{props.term}</td>
+              </tr>
+              <tr>
+                <td>
+                  <strong>(C) Definition:</strong>
+                </td>
+                <td>{props.definition}</td>
+              </tr>
+              <tr>
+                <td>
+                  <strong>Why it's wrong:</strong>
+                </td>
+                <td>{props.rejectionText}</td>
+              </tr>
+              <tr>
+                <td colSpan={2}>{linkToEditPage(props.cardId)}</td>
+              </tr>
+            </tbody>
+          </Table>
           <Grid grow justify="center" align="stretch" gutter="xs">
             <Grid.Col span={4}>
               <Button onClick={props.onClose}>

--- a/koala/quiz-failure.tsx
+++ b/koala/quiz-failure.tsx
@@ -26,7 +26,7 @@ export function QuizFailure(props: {
   ]);
   return (
     <Container size="xs">
-      <Grid grow justify="center" align="center">
+      <Grid justify="center" align="center">
         <Grid.Col>
           <header
             style={{
@@ -76,7 +76,7 @@ export function QuizFailure(props: {
               </tr>
             </tbody>
           </Table>
-          <Grid grow justify="center" align="stretch" gutter="xs">
+          <Grid>
             <Grid.Col span={4}>
               <Button onClick={props.onClose}>
                 Continue ({HOTKEYS.CONTINUE.toUpperCase()})

--- a/koala/routers/bulk-create-cards.ts
+++ b/koala/routers/bulk-create-cards.ts
@@ -16,8 +16,8 @@ export const bulkCreateCards = procedure
       input: z
         .array(
           z.object({
-            term: z.string().max(1000),
-            definition: z.string(),
+            term: z.string().max(200),
+            definition: z.string().max(200),
             gender: z.union([z.literal("M"), z.literal("F"), z.literal("N")]),
           }),
         )

--- a/koala/routers/get-next-quizzes.ts
+++ b/koala/routers/get-next-quizzes.ts
@@ -26,8 +26,8 @@ const QuizList = z.object({
 
 export async function getLessonMeta(userId: string) {
   const currentDate = new Date().getTime(); // Current time in milliseconds
-  const yesterday = currentDate - 24 * 60 * 60 * 1000;
-
+  // const yesterday = currentDate - 24 * 60 * 60 * 1000;
+  console.log(`==== ${currentDate}`);
   const quizzesDue = await prismaClient.quiz.count({
     where: {
       Card: {
@@ -40,9 +40,9 @@ export async function getLessonMeta(userId: string) {
       nextReview: {
         lt: currentDate,
       },
-      lastReview: {
-        lt: yesterday,
-      },
+      // lastReview: {
+      //   lt: yesterday,
+      // },
       firstReview: {
         gt: 0,
       },

--- a/koala/routers/get-next-quizzes.ts
+++ b/koala/routers/get-next-quizzes.ts
@@ -14,6 +14,7 @@ export const Quiz = z.object({
   lessonType: z.union([z.literal("listening"), z.literal("speaking")]),
   audio: z.string(),
   langCode: z.string(),
+  lastReview: z.number(),
 });
 
 const QuizList = z.object({

--- a/koala/routers/get-next-quizzes.ts
+++ b/koala/routers/get-next-quizzes.ts
@@ -26,15 +26,22 @@ const QuizList = z.object({
 
 export async function getLessonMeta(userId: string) {
   const currentDate = new Date().getTime(); // Current time in milliseconds
+  const yesterday = currentDate - 24 * 60 * 60 * 1000;
 
   const quizzesDue = await prismaClient.quiz.count({
     where: {
       Card: {
         userId: userId,
-        flagged: false,
+        flagged: { not: true },
+      },
+      quizType: {
+        in: ["listening", "speaking"],
       },
       nextReview: {
         lt: currentDate,
+      },
+      lastReview: {
+        lt: yesterday,
       },
       firstReview: {
         gt: 0,

--- a/koala/routers/get-next-quizzes.ts
+++ b/koala/routers/get-next-quizzes.ts
@@ -51,13 +51,16 @@ export async function getLessonMeta(userId: string) {
   });
 
   // Cards that have no quiz yet:
-  const newCards = await prismaClient.card.count({
+  // Count of Quizzes where repetitions and lapses are 0
+  // by distinct cardID
+  const newCards = await prismaClient.quiz.count({
     where: {
-      userId: userId,
-      flagged: false,
-      Quiz: {
-        none: {},
+      Card: {
+        userId: userId,
+        flagged: false,
       },
+      repetitions: 0,
+      lapses: 0,
     },
   });
   return {

--- a/koala/routers/get-next-quizzes.ts
+++ b/koala/routers/get-next-quizzes.ts
@@ -27,7 +27,7 @@ const QuizList = z.object({
 export async function getLessonMeta(userId: string) {
   const currentDate = new Date().getTime(); // Current time in milliseconds
   // const yesterday = currentDate - 24 * 60 * 60 * 1000;
-  console.log(`==== ${currentDate}`);
+
   const quizzesDue = await prismaClient.quiz.count({
     where: {
       Card: {

--- a/koala/routers/get-one-card.ts
+++ b/koala/routers/get-one-card.ts
@@ -1,6 +1,8 @@
 import { z } from "zod";
 import { procedure } from "../trpc-procedure";
 import { getCardOrFail } from "@/koala/get-card-or-fail";
+import { Quiz } from "./get-next-quizzes";
+import { LessonType } from "../fetch-lesson";
 
 export const getOneCard = procedure
   .input(
@@ -14,6 +16,7 @@ export const getOneCard = procedure
       definition: z.string(),
       term: z.string(),
       flagged: z.boolean(),
+      quizzes: z.array(Quiz),
     }),
   )
   .query(async ({ input, ctx }) => {
@@ -23,5 +26,19 @@ export const getOneCard = procedure
       definition: card.definition,
       term: card.term,
       flagged: card.flagged,
+      quizzes: card.Quiz.map((quiz) => {
+        return {
+          quizId: quiz.id,
+          cardId: card.id,
+          definition: card.definition,
+          term: card.term,
+          repetitions: quiz.repetitions,
+          lapses: quiz.lapses,
+          lessonType: quiz.quizType as LessonType,
+          audio: "",
+          langCode: card.langCode,
+          lastReview: quiz.lastReview,
+        };
+      }),
     };
   });

--- a/koala/routers/import-cards.ts
+++ b/koala/routers/import-cards.ts
@@ -106,8 +106,8 @@ export async function setGrade(
       ...calculateSchedulingData(quiz, grade, now),
     },
   };
-  await prismaClient.quiz.update(data);
+  const x = await prismaClient.quiz.update(data);
   console.log(
-    `Quiz ${data.data.id} next review: ${timeUntil(data.data.nextReview)}`,
+    `Quiz ${data.data.id} next review: ${timeUntil(x.nextReview)}`,
   );
 }

--- a/koala/routers/import-cards.ts
+++ b/koala/routers/import-cards.ts
@@ -107,7 +107,5 @@ export async function setGrade(
     },
   };
   const x = await prismaClient.quiz.update(data);
-  console.log(
-    `Quiz ${data.data.id} next review: ${timeUntil(x.nextReview)}`,
-  );
+  console.log(`Quiz ${data.data.id} next review: ${timeUntil(x.nextReview)}`);
 }

--- a/koala/routers/import-cards.ts
+++ b/koala/routers/import-cards.ts
@@ -80,11 +80,11 @@ async function setGradeFirstTime(
     lapses: grade === Grade.AGAIN ? quiz.lapses + 1 : quiz.lapses,
     repetitions: 1,
   };
-  console.log(`Set first SRS scheduling: ${timeUntil(nextQuiz.nextReview)}`);
   await prismaClient.quiz.update({
     where: { id: quiz.id },
     data: nextQuiz,
   });
+  console.log(`Set first SRS scheduling: ${timeUntil(nextQuiz.nextReview)}`);
 }
 
 export async function setGrade(

--- a/koala/routers/main.ts
+++ b/koala/routers/main.ts
@@ -12,7 +12,6 @@ import { getNextQuiz, getNextQuizzes } from "./get-next-quizzes";
 import { getOneCard } from "./get-one-card";
 import { getUserSettings } from "./get-user-settings";
 import { gradeQuiz } from "./grade-quiz";
-import { importCards } from "./import-cards";
 import { manuallyGrade } from "./manually-grade";
 import { parseCards } from "./parse-cards";
 import { rollbackGrade } from "./rollback-grade";
@@ -32,7 +31,6 @@ export const appRouter = router({
   getOneCard,
   getUserSettings,
   gradeQuiz,
-  importCards,
   manuallyGrade,
   parseCards,
   rollbackGrade,

--- a/koala/routers/rollback-grade.ts
+++ b/koala/routers/rollback-grade.ts
@@ -36,8 +36,8 @@ export const rollbackGrade = procedure
         lapses: Math.max(quiz.lapses - 1, 0),
       },
     };
+    await prismaClient.quiz.update(data);
     console.log(
       `Rollback grade. Next review: ${timeUntil(data.data.nextReview)}`,
     );
-    prismaClient.quiz.update(data);
   });

--- a/koala/settings-provider.tsx
+++ b/koala/settings-provider.tsx
@@ -36,11 +36,14 @@ export const UserSettingsProvider = ({
         color: "red",
       });
     };
-    getUserSettings.mutateAsync({}).then((userSettings) => {
-      if (userSettings) {
-        setUserSettings(userSettings);
-      }
-    }, err).finally(() => setLoading(false));
+    getUserSettings
+      .mutateAsync({})
+      .then((userSettings) => {
+        if (userSettings) {
+          setUserSettings(userSettings);
+        }
+      }, err)
+      .finally(() => setLoading(false));
   }, []);
 
   const clickLogin = () => {
@@ -67,7 +70,7 @@ export const UserSettingsProvider = ({
     </Container>
   );
   const a = <div>Loading...</div>;
-  const b = (userSettings.id ? children : login);
+  const b = userSettings.id ? children : login;
   return (
     <UserSettingsContext.Provider value={userSettings || EMPTY}>
       {loading ? a : b}

--- a/koala/study_reducer.ts
+++ b/koala/study_reducer.ts
@@ -10,6 +10,7 @@ export type Quiz = {
   quizId: number;
   repetitions: number;
   langCode: string;
+  lastReview: number;
 };
 
 export type Failure = {

--- a/koala/study_reducer.ts
+++ b/koala/study_reducer.ts
@@ -35,9 +35,9 @@ type CurrentItem =
   | { type: "none"; value: undefined };
 
 export type State = {
+  isRecording: boolean;
   cardsById: Record<string, Quiz>;
   failures: Failure[];
-  isRecording: boolean;
   idsAwaitingGrades: number[];
   idsWithErrors: number[];
   quizIDsForLesson: number[];
@@ -85,6 +85,7 @@ export function gotoNextQuiz(state: State): State {
     return {
       ...state,
       currentItem: { type: "failure", value: nextFailure },
+      quizIDsForLesson: betterUnique(state.quizIDsForLesson),
       failures: restFailures,
     };
   }

--- a/koala/study_reducer.ts
+++ b/koala/study_reducer.ts
@@ -183,7 +183,13 @@ function reduce(state: State, action: Action): State {
       });
       return removeCard(state2, action.id);
     case "FLAG_QUIZ":
-      return gotoNextQuiz(state);
+      const filter = (quizID: number) =>
+        state.cardsById[quizID]?.cardId !== action.cardId;
+      return gotoNextQuiz({
+        ...state,
+        // Remove all quizzes with this cardID
+        quizIDsForLesson: state.quizIDsForLesson.filter(filter),
+      });
     case "END_RECORDING":
       const arr = [...state.idsAwaitingGrades, action.id];
       const set = new Set(arr);

--- a/koala/transcribe.ts
+++ b/koala/transcribe.ts
@@ -19,8 +19,13 @@ export const captureAudio = (dataURI: string): string => {
 
 type TranscriptionResult = { kind: "OK"; text: string } | { kind: "error" };
 
-const PROMPT_KO = "다양한 예문을 읽는 연습";
-const PROMPT_EN = "Trascript of an example sentence.";
+const PROMPTS: Record<string, string> = {
+  ko: "다양한 한국어 예문을 읽는 연습",
+  en: "Reading diverse example sentences in English ",
+  it: "Esercizio di lettura di frasi esemplificative in italiano",
+  fr: "Exercice de lecture de phrases d'exemple en français",
+  es: "Ejercicio de lectura de frases de ejemplo en español",
+};
 
 const transcriptionLength = SafeCounter({
   name: "transcriptionLength",
@@ -42,14 +47,14 @@ export async function transcribeB64(
     ext: ".wav",
   });
   await writeFileAsync(fpath, buffer);
-  const isEn = lang.slice(0, 2) === "en";
+  const prompt = PROMPTS[lang.slice(0, 2)] || PROMPTS.ko;
   const transcribePromise = new Promise<TranscriptionResult>(
     async (resolve) => {
       try {
         const y = await openai.audio.transcriptions.create({
           file: createReadStream(fpath) as any,
           model: "whisper-1",
-          prompt: isEn ? PROMPT_EN : PROMPT_KO,
+          prompt,
         });
         const text = y.text || "NO RESPONSE.";
         transcriptionLength.labels({ lang, userID }).inc(y.text.length);

--- a/pages/cards.tsx
+++ b/pages/cards.tsx
@@ -1,22 +1,7 @@
 import { CardTable } from "@/koala/card-table";
 import { trpc } from "@/koala/trpc-config";
-import { Button, Container, FileButton } from "@mantine/core";
+import { Button, Container } from "@mantine/core";
 import { z } from "zod";
-
-export const OLD_BACKUP_SCHEMA = z.array(
-  z.object({
-    definition: z.string(),
-    term: z.string(),
-    ease: z.number(),
-    interval: z.number(),
-    lapses: z.number(),
-    repetitions: z.number(),
-    nextReviewAt: z.number(),
-    createdAt: z.coerce.date(),
-    firstReview: z.nullable(z.coerce.date()),
-    lastReview: z.nullable(z.coerce.date()),
-  }),
-);
 
 export const BACKUP_SCHEMA = z.array(
   z.object({
@@ -39,44 +24,11 @@ export const BACKUP_SCHEMA = z.array(
   }),
 );
 
-interface FileImportButtonProps {
-  onReady: (data: z.infer<typeof OLD_BACKUP_SCHEMA>) => void;
-}
-
-// Create a file import button.
-// It's a file picker that has an "onReady" callback.
-// When the user selects a file, it calls the callback with the file contents:
-const FileImportButton = ({ onReady }: FileImportButtonProps) => {
-  const onChange = (file: File | null) => {
-    if (!file) return;
-    const reader = new FileReader();
-    reader.onload = (e) => {
-      const data = e.target?.result as string;
-      // Ensure that `data` complies with the backup schema:
-      const parsed = OLD_BACKUP_SCHEMA.safeParse(JSON.parse(data));
-      if (parsed.success) {
-        onReady(parsed.data);
-      } else {
-        const e = parsed.error.message.slice(0, 80);
-        alert("Invalid backup file: " + e);
-        return;
-      }
-    };
-    reader.readAsText(file);
-  };
-  return (
-    <FileButton onChange={onChange} accept="application/jpeg">
-      {(props) => <Button {...props}>Import Cards (v2)</Button>}
-    </FileButton>
-  );
-};
-
 const Edit: React.FC = () => {
   /** Call the "getAllCards" trpc method. */
   const cards = trpc.getAllCards.useQuery({});
   const deleteFlagged = trpc.deleteFlaggedCards.useMutation();
   const exportCards = trpc.exportCards.useMutation();
-  const importCards = trpc.importCards.useMutation();
   const doDeleteFlagged = () => {
     const warning = "Are you sure you want to delete all flagged cards?";
     if (!confirm(warning)) return;
@@ -103,16 +55,6 @@ const Edit: React.FC = () => {
       <h1>Manage Cards</h1>
       <Button onClick={doDeleteFlagged}>Delete Flagged Cards</Button>
       <Button onClick={doExport}>Export Cards (V3)</Button>
-      <FileImportButton
-        onReady={(data) => {
-          const desired = data.length;
-          alert("This is going to take a while. Are you ready?");
-          importCards.mutateAsync(data).then(({ count }) => {
-            alert(`Imported ${count}/${desired} cards.`);
-            location.reload();
-          });
-        }}
-      />
       <hr />
       {content}
     </Container>

--- a/pages/cards/[card_id].tsx
+++ b/pages/cards/[card_id].tsx
@@ -1,7 +1,27 @@
+import { timeUntil } from "@/koala/time-until";
 import { trpc } from "@/koala/trpc-config";
 import { Button, Checkbox, Container, Paper, TextInput } from "@mantine/core";
 import { useForm } from "@mantine/form";
 import { useRouter } from "next/router";
+
+type LocalQuiz = {
+  repetitions: number;
+  lapses: number;
+  lessonType: string;
+  lastReview: number;
+};
+
+function CardQuiz(props: LocalQuiz) {
+  const when = props.lastReview ? timeUntil(props.lastReview) : "never";
+  return (
+    <div>
+      <h2>{props.lessonType.toUpperCase()}</h2>
+      <p>Repetitions: {props.repetitions}</p>
+      <p>Lapses: {props.lapses}</p>
+      <p>Last Review: {when}</p>
+    </div>
+  );
+}
 
 function Card({ id }: { id: number }) {
   const router = useRouter();
@@ -54,6 +74,7 @@ function Card({ id }: { id: number }) {
       <Paper shadow="xs">
         <form onSubmit={form.onSubmit(updateForm)}>
           <Container size="md">
+            <h1>Card {card.data.id}</h1>
             <TextInput
               label="Definition"
               placeholder="Enter Definition"
@@ -77,6 +98,10 @@ function Card({ id }: { id: number }) {
             Delete
           </Button>
         </form>
+        <h1>Quiz Data</h1>
+        {card.data.quizzes.map((quiz) => {
+          return <CardQuiz key={quiz.quizId} {...quiz} />;
+        })}
       </Paper>
     </div>
   );

--- a/pages/study.tsx
+++ b/pages/study.tsx
@@ -235,10 +235,13 @@ function useBusinessLogic(state: State, dispatch: Dispatch<Action>) {
 }
 
 function useQuizState(props: QuizData) {
-  const cardsById = props.quizzes.reduce((acc, quiz) => {
-    acc[quiz.quizId] = quiz;
-    return acc;
-  }, {} as Record<number, Quiz>);
+  const cardsById = props.quizzes.reduce(
+    (acc, quiz) => {
+      acc[quiz.quizId] = quiz;
+      return acc;
+    },
+    {} as Record<number, Quiz>,
+  );
   const newState = gotoNextQuiz(
     newQuizState({
       cardsById,
@@ -428,7 +431,7 @@ function LoadedStudyPage(props: QuizData) {
     case "none":
       const willGrade = state.idsAwaitingGrades.length;
       if (willGrade) {
-        el = <div>Waiting for the server to grade ${willGrade} quizzes.</div>;
+        el = <div>Waiting for the server to grade {willGrade} quizzes.</div>;
         break;
       }
       el = <NoQuizDue />;

--- a/pages/study.tsx
+++ b/pages/study.tsx
@@ -45,6 +45,7 @@ type HotkeyButtonProps = {
   hotkey: string;
   label: string;
   onClick: () => void;
+  disabled?: boolean;
 };
 
 const HEADER_STYLES = {
@@ -288,7 +289,7 @@ function NoQuizDue(_: {}) {
 function HotkeyButton(props: HotkeyButtonProps) {
   return (
     <Grid.Col span={GRID_SIZE}>
-      <Button fullWidth onClick={props.onClick}>
+      <Button fullWidth onClick={props.onClick} disabled={props.disabled}>
         {props.label} ({props.hotkey.toUpperCase()})
       </Button>
     </Grid.Col>
@@ -297,6 +298,14 @@ function HotkeyButton(props: HotkeyButtonProps) {
 
 function QuizView(props: QuizViewProps) {
   const { quiz } = props;
+  const [maxGrade, setMaxGrade] = useState(Grade.EASY);
+  // Reduce maxGrade after a 5 second timeout:
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setMaxGrade(maxGrade - 1);
+    }, 8000);
+    return () => clearTimeout(timer);
+  }, [maxGrade]);
   useEffect(() => {
     props.playQuizAudio();
   }, [props.quiz.quizId]);
@@ -320,27 +329,37 @@ function QuizView(props: QuizViewProps) {
       onClick: () => props.startRecording(Grade.AGAIN),
       label: "FAIL",
       hotkey: HOTKEYS.FAIL,
+      disabled: false,
     },
     {
       onClick: () => props.startRecording(Grade.HARD),
       label: "Hard",
       hotkey: HOTKEYS.HARD,
+      disabled: false,
     },
     {
       onClick: () => props.startRecording(Grade.GOOD),
       label: "Good",
       hotkey: HOTKEYS.GOOD,
+      disabled: maxGrade < Grade.GOOD,
     },
     {
       onClick: () => props.startRecording(Grade.EASY),
       label: "Easy",
       hotkey: HOTKEYS.EASY,
+      disabled: maxGrade < Grade.EASY,
     },
   ];
   let buttonCluster = (
     <Grid grow justify="center" align="stretch" gutter="xs">
       <Grid.Col span={6}>
-        <Button fullWidth onClick={props.playQuizAudio}>
+        <Button
+          fullWidth
+          onClick={() => {
+            setMaxGrade(maxGrade - 1);
+            props.playQuizAudio();
+          }}
+        >
           Play Audio ({HOTKEYS.PLAY.toUpperCase()})
         </Button>
       </Grid.Col>

--- a/pages/study.tsx
+++ b/pages/study.tsx
@@ -285,7 +285,7 @@ function HotkeyButton(props: HotkeyButtonProps) {
   return (
     <Grid.Col span={GRID_SIZE}>
       <Button fullWidth onClick={props.onClick}>
-        {props.label} ({props.hotkey})
+        {props.label} ({props.hotkey.toUpperCase()})
       </Button>
     </Grid.Col>
   );
@@ -337,12 +337,12 @@ function QuizView(props: QuizViewProps) {
     <Grid grow justify="center" align="stretch" gutter="xs">
       <Grid.Col span={6}>
         <Button fullWidth onClick={props.playQuizAudio}>
-          Play Audio ({HOTKEYS.PLAY})
+          Play Audio ({HOTKEYS.PLAY.toUpperCase()})
         </Button>
       </Grid.Col>
       <Grid.Col span={6}>
         <Button fullWidth onClick={props.flagQuiz}>
-          Pause Reviews ({HOTKEYS.FLAG})
+          Pause Reviews ({HOTKEYS.FLAG.toUpperCase()})
         </Button>
       </Grid.Col>
       {buttons.map((p) => (

--- a/pages/study.tsx
+++ b/pages/study.tsx
@@ -11,6 +11,7 @@ import {
   newQuizState,
   quizReducer,
 } from "@/koala/study_reducer";
+import { timeUntil } from "@/koala/time-until";
 import { trpc } from "@/koala/trpc-config";
 import { useVoiceRecorder } from "@/koala/use-recorder";
 import { Button, Container, Grid } from "@mantine/core";
@@ -364,6 +365,7 @@ function QuizView(props: QuizViewProps) {
     );
   }
 
+  const when = quiz.lastReview ? timeUntil(quiz.lastReview) : "never";
   return (
     <>
       <StudyHeader
@@ -371,9 +373,10 @@ function QuizView(props: QuizViewProps) {
         langCode={props.quiz.langCode}
       />
       {buttonCluster}
-      <p>Card #{quiz.quizId} quiz</p>
+      <p>Quiz #{quiz.quizId}</p>
       <p>{quiz.repetitions} repetitions</p>
       <p>{quiz.lapses} lapses</p>
+      <p>Last seen: {when}</p>
       <p>
         {props.totalCards} cards total, {props.quizzesDue} due, {props.newCards}{" "}
         new, {props.awaitingGrades} awaiting grades, {props.queueSize} in study
@@ -423,6 +426,11 @@ function LoadedStudyPage(props: QuizData) {
       );
       break;
     case "none":
+      const willGrade = state.idsAwaitingGrades.length;
+      if (willGrade) {
+        el = <div>Waiting for the server to grade ${willGrade} quizzes.</div>;
+        break;
+      }
       el = <NoQuizDue />;
       break;
     case "loading":

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -95,11 +95,11 @@ model Quiz {
   cardId      Int
   Card        Card   @relation(fields: [cardId], references: [id], onDelete: Cascade)
   quizType    String
-  stability   Float
-  difficulty  Float
-  firstReview Float
-  lastReview  Float
-  nextReview  Float
+  stability   Float  @default(0)
+  difficulty  Float  @default(0)
+  firstReview Float  @default(0)
+  lastReview  Float  @default(0)
+  nextReview  Float  @default(0)
   lapses      Float  @default(0)
   repetitions Float  @default(0)
 


### PR DESCRIPTION
Fix bug when fetching cards that are due
90/10 mix of old/new cards for now until I bring back "max new" setting from v2
dont call LLM on exact matches
Align columns on quiz failure modal
Penalize user for audio replay and slow responses
don't show failures until there are 5 failures to review.
bug fix: non-Korean voice input was being sent to Whisper as if it were Korean
set database defaults for quiz stats to 0 to prevent NaN errors